### PR TITLE
fix(colors): Remove multicolors support

### DIFF
--- a/src/addons/sourcemod/scripting/zombiereloaded.sp
+++ b/src/addons/sourcemod/scripting/zombiereloaded.sp
@@ -45,7 +45,7 @@
 
 #include <sdkhooks>
 
-#define VERSION "3.10.14"
+#define VERSION "3.10.16"
 
 // Comment this line to exclude version info command. Enable this if you have
 // the repository and HG installed (Mercurial or TortoiseHG).

--- a/src/addons/sourcemod/scripting/zombiereloaded.sp
+++ b/src/addons/sourcemod/scripting/zombiereloaded.sp
@@ -32,7 +32,6 @@
 #include <sdktools>
 #include <clientprefs>
 #include <cstrike>
-#tryinclude <multicolors>
 #define INCLUDED_BY_ZOMBIERELOADED
 #include <zombiereloaded>
 #undef INCLUDED_BY_ZOMBIERELOADED

--- a/src/addons/sourcemod/scripting/zr/translation.inc
+++ b/src/addons/sourcemod/scripting/zr/translation.inc
@@ -85,43 +85,30 @@ stock void TranslationTranslatePhrase(int client, char[] translation, int maxlen
  */
 stock void TranslationPluginFormatString(char[] text, int maxlen, bool color = true)
 {
-    LogMessage("1. color: %d | text: %s", color, text);
     if (color)
     {
-        LogMessage("1. color: %d | text: %s", color, text);
         // Format prefix onto the string.
         Format(text, maxlen, "@green%s @default%s", TRANSLATION_PHRASE_PREFIX, text);
-        LogMessage("2. color: %d | text: %s", color, text);
 
         // Replace color tokens with game color chars.
-    #if defined _multicolors_included
-        ReplaceString(text, maxlen, "@default", "{default}");
-        ReplaceString(text, maxlen, "@lgreen", "{lightgreen}");
-        ReplaceString(text, maxlen, "@green", "{green}");
+    // #if defined _multicolors_included
+    //     ReplaceString(text, maxlen, "@default", "{default}");
+    //     ReplaceString(text, maxlen, "@lgreen", "{lightgreen}");
+    //     ReplaceString(text, maxlen, "@green", "{green}");
 
-        CFormatColor(text, maxlen, 0);
-        CAddWhiteSpace(text, maxlen);
-    #else
+    //     CFormatColor(text, maxlen, 0);
+    //     CAddWhiteSpace(text, maxlen);
+    // #else
         ReplaceString(text, maxlen, "@default", TRANSLATION_TEXT_COLOR_DEFAULT);
         ReplaceString(text, maxlen, "@lgreen", TRANSLATION_TEXT_COLOR_LGREEN);
         ReplaceString(text, maxlen, "@green", TRANSLATION_TEXT_COLOR_GREEN);
-    #endif
+    // #endif
 
-        LogMessage("3. color: %d | text: %s", color, text);
         return;
-    }
-    else
-    {
-        // No color formatting, remove color tokens.
-        ReplaceString(text, maxlen, "@default", "");
-        ReplaceString(text, maxlen, "@lgreen", "");
-        ReplaceString(text, maxlen, "@green", "");
-        LogMessage("4. color: %d | text: %s", color, text);
     }
 
     // Format prefix onto the string.
     Format(text, maxlen, "%s %s", TRANSLATION_PHRASE_PREFIX, text);
-    LogMessage("5. color: %d | text: %s", color, text);
 }
 
 /**

--- a/src/addons/sourcemod/scripting/zr/translation.inc
+++ b/src/addons/sourcemod/scripting/zr/translation.inc
@@ -106,6 +106,13 @@ stock void TranslationPluginFormatString(char[] text, int maxlen, bool color = t
 
         return;
     }
+    else
+    {
+        // No color formatting, remove color tokens.
+        ReplaceString(text, maxlen, "@default", "");
+        ReplaceString(text, maxlen, "@lgreen", "");
+        ReplaceString(text, maxlen, "@green", "");
+    }
 
     // Format prefix onto the string.
     Format(text, maxlen, "%s %s", TRANSLATION_PHRASE_PREFIX, text);

--- a/src/addons/sourcemod/scripting/zr/translation.inc
+++ b/src/addons/sourcemod/scripting/zr/translation.inc
@@ -90,19 +90,15 @@ stock void TranslationPluginFormatString(char[] text, int maxlen, bool color = t
         // Format prefix onto the string.
         Format(text, maxlen, "@green%s @default%s", TRANSLATION_PHRASE_PREFIX, text);
 
-        // Replace color tokens with game color chars.
-    #if defined _multicolors_included
-        ReplaceString(text, maxlen, "@default", "{default}");
-        ReplaceString(text, maxlen, "@lgreen", "{lightgreen}");
-        ReplaceString(text, maxlen, "@green", "{green}");
-
-        CFormatColor(text, maxlen, 0);
-        CAddWhiteSpace(text, maxlen);
-    #else
+        // Replace color tokens with CS:S color chars.
         ReplaceString(text, maxlen, "@default", TRANSLATION_TEXT_COLOR_DEFAULT);
         ReplaceString(text, maxlen, "@lgreen", TRANSLATION_TEXT_COLOR_LGREEN);
         ReplaceString(text, maxlen, "@green", TRANSLATION_TEXT_COLOR_GREEN);
-    #endif
+
+        // Backwards compatibility with multicolors.inc
+        ReplaceString(text, maxlen, "{default}", TRANSLATION_TEXT_COLOR_DEFAULT);
+        ReplaceString(text, maxlen, "{lightgreen}", TRANSLATION_TEXT_COLOR_LGREEN);
+        ReplaceString(text, maxlen, "{green}", TRANSLATION_TEXT_COLOR_GREEN);
 
         return;
     }
@@ -449,13 +445,11 @@ stock void TranslationReplyToCommand(int client, any ...)
     {
         // Format string to create plugin style. (color)
         TranslationPluginFormatString(translation, sizeof(translation));
-        PrintToChatAll("Client %N is valid", client);
     }
     else
     {
         // Format string to create plugin style. (no color)
         TranslationPluginFormatString(translation, sizeof(translation), false);
-        PrintToChatAll("Client %N is invalid", client);
     }
 
     // Print translated phrase to server or client's chat/console.

--- a/src/addons/sourcemod/scripting/zr/translation.inc
+++ b/src/addons/sourcemod/scripting/zr/translation.inc
@@ -85,11 +85,13 @@ stock void TranslationTranslatePhrase(int client, char[] translation, int maxlen
  */
 stock void TranslationPluginFormatString(char[] text, int maxlen, bool color = true)
 {
-    LogMessage(text);
+    LogMessage("1. color: %d | text: %s", color, text);
     if (color)
     {
+        LogMessage("1. color: %d | text: %s", color, text);
         // Format prefix onto the string.
         Format(text, maxlen, "@green%s @default%s", TRANSLATION_PHRASE_PREFIX, text);
+        LogMessage("2. color: %d | text: %s", color, text);
 
         // Replace color tokens with game color chars.
     #if defined _multicolors_included
@@ -105,6 +107,7 @@ stock void TranslationPluginFormatString(char[] text, int maxlen, bool color = t
         ReplaceString(text, maxlen, "@green", TRANSLATION_TEXT_COLOR_GREEN);
     #endif
 
+        LogMessage("3. color: %d | text: %s", color, text);
         return;
     }
     else
@@ -113,11 +116,12 @@ stock void TranslationPluginFormatString(char[] text, int maxlen, bool color = t
         ReplaceString(text, maxlen, "@default", "");
         ReplaceString(text, maxlen, "@lgreen", "");
         ReplaceString(text, maxlen, "@green", "");
+        LogMessage("4. color: %d | text: %s", color, text);
     }
 
     // Format prefix onto the string.
     Format(text, maxlen, "%s %s", TRANSLATION_PHRASE_PREFIX, text);
-    LogMessage(text);
+    LogMessage("5. color: %d | text: %s", color, text);
 }
 
 /**

--- a/src/addons/sourcemod/scripting/zr/translation.inc
+++ b/src/addons/sourcemod/scripting/zr/translation.inc
@@ -96,8 +96,8 @@ stock void TranslationPluginFormatString(char[] text, int maxlen, bool color = t
         ReplaceString(text, maxlen, "@lgreen", "{lightgreen}");
         ReplaceString(text, maxlen, "@green", "{green}");
 
-        // CFormatColor(text, maxlen, 0);
-        // CAddWhiteSpace(text, maxlen);
+        CFormatColor(text, maxlen, 0);
+        CAddWhiteSpace(text, maxlen);
     #else
         ReplaceString(text, maxlen, "@default", TRANSLATION_TEXT_COLOR_DEFAULT);
         ReplaceString(text, maxlen, "@lgreen", TRANSLATION_TEXT_COLOR_LGREEN);
@@ -449,11 +449,13 @@ stock void TranslationReplyToCommand(int client, any ...)
     {
         // Format string to create plugin style. (color)
         TranslationPluginFormatString(translation, sizeof(translation));
+        PrintToChatAll("Client %N is valid", client);
     }
     else
     {
         // Format string to create plugin style. (no color)
         TranslationPluginFormatString(translation, sizeof(translation), false);
+        PrintToChatAll("Client %N is invalid", client);
     }
 
     // Print translated phrase to server or client's chat/console.

--- a/src/addons/sourcemod/scripting/zr/translation.inc
+++ b/src/addons/sourcemod/scripting/zr/translation.inc
@@ -91,18 +91,18 @@ stock void TranslationPluginFormatString(char[] text, int maxlen, bool color = t
         Format(text, maxlen, "@green%s @default%s", TRANSLATION_PHRASE_PREFIX, text);
 
         // Replace color tokens with game color chars.
-    // #if defined _multicolors_included
-    //     ReplaceString(text, maxlen, "@default", "{default}");
-    //     ReplaceString(text, maxlen, "@lgreen", "{lightgreen}");
-    //     ReplaceString(text, maxlen, "@green", "{green}");
+    #if defined _multicolors_included
+        ReplaceString(text, maxlen, "@default", "{default}");
+        ReplaceString(text, maxlen, "@lgreen", "{lightgreen}");
+        ReplaceString(text, maxlen, "@green", "{green}");
 
-    //     CFormatColor(text, maxlen, 0);
-    //     CAddWhiteSpace(text, maxlen);
-    // #else
+        // CFormatColor(text, maxlen, 0);
+        // CAddWhiteSpace(text, maxlen);
+    #else
         ReplaceString(text, maxlen, "@default", TRANSLATION_TEXT_COLOR_DEFAULT);
         ReplaceString(text, maxlen, "@lgreen", TRANSLATION_TEXT_COLOR_LGREEN);
         ReplaceString(text, maxlen, "@green", TRANSLATION_TEXT_COLOR_GREEN);
-    // #endif
+    #endif
 
         return;
     }

--- a/src/addons/sourcemod/scripting/zr/translation.inc
+++ b/src/addons/sourcemod/scripting/zr/translation.inc
@@ -85,6 +85,7 @@ stock void TranslationTranslatePhrase(int client, char[] translation, int maxlen
  */
 stock void TranslationPluginFormatString(char[] text, int maxlen, bool color = true)
 {
+    LogMessage(text);
     if (color)
     {
         // Format prefix onto the string.
@@ -116,6 +117,7 @@ stock void TranslationPluginFormatString(char[] text, int maxlen, bool color = t
 
     // Format prefix onto the string.
     Format(text, maxlen, "%s %s", TRANSLATION_PHRASE_PREFIX, text);
+    LogMessage(text);
 }
 
 /**


### PR DESCRIPTION
Since the plugin only support CS:S now, no need to keep support for multicolors, color can stay hardcoded. 
fix #59